### PR TITLE
Fixed add movies from Rotten Tomatoes in 2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "Pulsarr",
   "author": "roboticsound",
   "description": "Add movies/series to Radarr/Sonarr from IMDB and TVDB",
-  "version": "2.1",
+  "version": "2.2",
 
   "icons": {
     "16": "/img/icons/pulsarr/16.png",

--- a/popup.js
+++ b/popup.js
@@ -905,9 +905,10 @@ let loadFromRottenUrl = async (url) => {
 	} else if (regexmov.test(url)) {
 		try {
 			let result = await $.ajax({url: url, datatype: "xml"});
-			var title = $(result).find("#movie-title").text().trim();
+			var title = $(result).find(".mop-ratings-wrap h1").text().trim();
 			let imdbid = await pulsarr.ImdbidFromTitle(title,1);
 			let movie = await radarr.lookupMovie(imdbid);
+
 			if (movie) {
 				pulsarr.info(movie);
 			}


### PR DESCRIPTION
The element id ```movie-title``` is no longer part of the DOM on Rotten Tomatoes movie pages. Changed title selector for RT movie pages to ```.mop-ratings-wrap h1```.