### PR TITLE
Update Chrome addon url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Pulsarr
 =======
 
-Browser extension (currently [Chrome](https://chrome.google.com/webstore/detail/pulsarr/dcildkalkckjjdfpgagmnbbfooogopkd) & [Firefox](https://addons.mozilla.org/firefox/addon/ffpulsarr)) for adding movies to Radarr or Series' to Sonarr while browsing IMDB or TVDB.
+Browser extension (currently [Chrome](https://chrome.google.com/webstore/detail/pulsarr/ekjjpacodipfmjhpbjcbnmnimakhlnne) & [Firefox](https://addons.mozilla.org/firefox/addon/ffpulsarr)) for adding movies to Radarr or Series' to Sonarr while browsing IMDB or TVDB.
 
 ## What's New
 - Bug fixes and code cleanup


### PR DESCRIPTION
The Chrome addon URL is outdated. Can this please get updated?